### PR TITLE
Simplify parse logic and reduce repetition

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -53,15 +53,6 @@ func (p *Pagser) ParseSelection(v interface{}, selection *goquery.Selection) (er
 	return p.doParse(val, nil, selection)
 }
 
-func (p *Pagser) doParsePointer(val reflect.Value, stackValues []reflect.Value, selection *goquery.Selection) (err error) {
-	err = p.doParse(reflect.Indirect(val), stackValues, selection)
-	if err != nil {
-		return err
-		// return fmt.Errorf("tag=`%v` %#v parser error: %v", tagValue, subModel, err)
-	}
-	return nil
-}
-
 // ParseSelection parse selection to struct
 func (p *Pagser) doParse(val reflect.Value, stackValues []reflect.Value, selection *goquery.Selection) (err error) {
 	switch val.Kind() {
@@ -188,6 +179,15 @@ func (p *Pagser) doParse(val reflect.Value, stackValues []reflect.Value, selecti
 		default:
 			fieldValue.SetString(strings.TrimSpace(node.Text()))
 		}
+	}
+	return nil
+}
+
+func (p *Pagser) doParsePointer(val reflect.Value, stackValues []reflect.Value, selection *goquery.Selection) (err error) {
+	err = p.doParse(reflect.Indirect(val), stackValues, selection)
+	if err != nil {
+		return err
+		// return fmt.Errorf("tag=`%v` %#v parser error: %v", tagValue, subModel, err)
 	}
 	return nil
 }

--- a/parse.go
+++ b/parse.go
@@ -97,7 +97,7 @@ func (p *Pagser) doParse(v interface{}, stackRefValues []reflect.Value, selectio
 		var callOutValue interface{}
 		var callErr error
 		if tag.FuncName != "" {
-			callOutValue, callErr = p.findAndExecFunc(objRefValue, stackRefValues, tag, node)
+			callOutValue, callErr = p.findAndExecFunc(objRefValueElem, stackRefValues, tag, node)
 			if callErr != nil {
 				return fmt.Errorf("tag=`%v` parse func error: %v", tagValue, callErr)
 			}
@@ -187,11 +187,11 @@ func (p *Pagser) doParse(v interface{}, stackRefValues []reflect.Value, selectio
 fieldType := refTypeElem.Field(i)
 fieldValue := refValueElem.Field(i)
 */
-func (p *Pagser) findAndExecFunc(objRefValue reflect.Value, stackRefValues []reflect.Value, selTag *tagTokenizer, node *goquery.Selection) (interface{}, error) {
+func (p *Pagser) findAndExecFunc(objRefValueElem reflect.Value, stackRefValues []reflect.Value, selTag *tagTokenizer, node *goquery.Selection) (interface{}, error) {
 	if selTag.FuncName != "" {
 
 		// call object method
-		callMethod := findMethod(objRefValue, selTag.FuncName)
+		callMethod := findMethod(objRefValueElem, selTag.FuncName)
 		if callMethod.IsValid() {
 			// execute method
 			return execMethod(callMethod, selTag, node)
@@ -225,13 +225,13 @@ func (p *Pagser) findAndExecFunc(objRefValue reflect.Value, stackRefValues []ref
 	return strings.TrimSpace(node.Text()), nil
 }
 
-func findMethod(objRefValue reflect.Value, funcName string) reflect.Value {
-	callMethod := objRefValue.MethodByName(funcName)
+func findMethod(objRefValueElem reflect.Value, funcName string) reflect.Value {
+	callMethod := objRefValueElem.MethodByName(funcName)
 	if callMethod.IsValid() {
 		return callMethod
 	}
 	// call element method
-	return objRefValue.Elem().MethodByName(funcName)
+	return objRefValueElem.MethodByName(funcName)
 }
 
 func execMethod(callMethod reflect.Value, selTag *tagTokenizer, node *goquery.Selection) (interface{}, error) {

--- a/parse.go
+++ b/parse.go
@@ -58,8 +58,23 @@ func (p *Pagser) doParse(val reflect.Value, stackValues []reflect.Value, selecti
 	switch val.Kind() {
 	case reflect.Pointer:
 		return p.doParsePointer(val, stackValues, selection)
+	case reflect.Struct:
+		return p.doParseStruct(val, stackValues, selection)
 	}
 
+	return nil
+}
+
+func (p *Pagser) doParsePointer(val reflect.Value, stackValues []reflect.Value, selection *goquery.Selection) (err error) {
+	err = p.doParse(reflect.Indirect(val), stackValues, selection)
+	if err != nil {
+		return err
+		// return fmt.Errorf("tag=`%v` %#v parser error: %v", tagValue, subModel, err)
+	}
+	return nil
+}
+
+func (p *Pagser) doParseStruct(val reflect.Value, stackValues []reflect.Value, selection *goquery.Selection) (err error) {
 	for i := 0; i < val.NumField(); i++ {
 		fieldValue := val.Field(i)
 		fieldType := val.Type().Field(i)
@@ -180,15 +195,7 @@ func (p *Pagser) doParse(val reflect.Value, stackValues []reflect.Value, selecti
 			fieldValue.SetString(strings.TrimSpace(node.Text()))
 		}
 	}
-	return nil
-}
 
-func (p *Pagser) doParsePointer(val reflect.Value, stackValues []reflect.Value, selection *goquery.Selection) (err error) {
-	err = p.doParse(reflect.Indirect(val), stackValues, selection)
-	if err != nil {
-		return err
-		// return fmt.Errorf("tag=`%v` %#v parser error: %v", tagValue, subModel, err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
Hugely simplify parse logic, complexity and redundant checks by:

- Only check if the input is pointer, not nil and underlying type is a struct, **once** in the public parse function - not every time we call `doParse`
- Split `doParse` into a series of individual `doParseX` functions, each called depending on the value `Kind` used in a switch
- Update the finding and executing of pagser methods to work if just a concrete value is passed, not relying on a pointer, allowing us to support the above more genericisied `doParse` function without having to keep track of the pointer for any concrete value passed, or make assumptions about the passed value
- Use this `doParse` function in the parsing of structs and slices (recursively) so we don't need to repeat logic in these.
- Simplify the repetition in the function to set field values, by reducing the number of if statements